### PR TITLE
Update behat PHP dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   },
   "require-dev": {
     "ext-simplexml": "*",
-    "bamarni/composer-bin-plugin": "^1.4"
+    "bamarni/composer-bin-plugin": "^1.8"
   },
   "extra": {
     "bamarni-bin": {

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -8,20 +8,20 @@
         }
     },
     "require": {
-        "behat/behat": "^3.8",
-        "behat/gherkin": "4.7.1",
+        "behat/behat": "^3.13",
+        "behat/gherkin": "^4.9",
         "behat/mink": "1.7.1",
-        "behat/mink-extension": "^2.3",
-        "behat/mink-selenium2-driver": "^1.4",
+        "friends-of-behat/mink-extension": "^2.7",
         "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.3",
-        "symfony/translation": "^4.4",
+        "symfony/translation": "^5.4",
         "sabre/xml": "^2.2",
-        "guzzlehttp/guzzle": "^7.2",
-        "phpunit/phpunit": "^9.4",
-        "laminas/laminas-ldap": "^2.10",
-        "ankitpokhrel/tus-php": "^2.1",
-        "wapmorgan/unified-archive": "^1.1.3"
+        "guzzlehttp/guzzle": "^7.7",
+        "phpunit/phpunit": "^9.6",
+        "laminas/laminas-ldap": "^2.15",
+        "ankitpokhrel/tus-php": "^2.3",
+        "wapmorgan/unified-archive": "^1.1.10",
+        "helmich/phpunit-json-assert": "^3.4"
     }
 }


### PR DESCRIPTION
to get the versions similar to what is used in CI for API acceptance tests with https://github.com/owncloud/ocis and https://github.com/owncloud/core

and add `helmich/phpunit-json-assert` which is needed these days by the acceptance test code.