### PR TITLE
Ignore composer output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Composer - used for PHP-based acceptance tests
+composer.lock
+vendor-bin/behat/vendor
+vendor-bin/behat/composer.lock
+vendor-php


### PR DESCRIPTION
After doing a local `composer install` in this repo, to see what versions of dependencies are actually found, there are the outputs of the `composer` command. We don't want to commit those, so have a `.gitignore` to make sure that they do not accidentally get committed.