### PR TITLE
Use PHP 8.2 for Behat acceptance tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM owncloudci/php:7.4
+FROM owncloudci/php:8.2
 
 WORKDIR /root
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "cs3org/reva",
   "config" : {
     "platform": {
-      "php": "7.4"
+      "php": "8.2"
     },
     "vendor-dir": "./vendor-php",
     "allow-plugins": {

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.4"
+            "php": "8.2"
         },
         "allow-plugins": {
             "composer/package-versions-deprecated": true


### PR DESCRIPTION
We are now using PHP 8.2 for Behat acceptance tests in ocis.
https://github.com/owncloud/ocis/pull/8889

Do the same here in cs3org